### PR TITLE
Fix for quest reward quantity

### DIFF
--- a/scripts/sheets/base-sheet.js
+++ b/scripts/sheets/base-sheet.js
@@ -1474,7 +1474,7 @@ _onObjectiveDragStart(event) {
               ui.notifications.warn("Item already exists in this quest's inventory!");
               return;
           }
-          quest.inventory.push({ itemUuid: item.uuid, quantity: 1, customPrice: null });
+          quest.inventory.push({ itemUuid: item.uuid, quantity: item.system?.quantity ?? 1, customPrice: null });
           await this.document.setFlag("campaign-codex", "data.quests", quests);
           this.render(true);
           ui.notifications.info(`Added "${item.name}" to quest "${quest.title}"`);


### PR DESCRIPTION
Instead of adding 1 copy of an item dropped into a quest, the item's quantity will be taken into account. I'm not an expert at JS, but I tried to make sure nothing will break if the quantity cannot be read, and it defaults to 1 if anything happens.

<img width="413" height="176" alt="image" src="https://github.com/user-attachments/assets/0798bd20-893f-4668-bbc1-03953385bec0" />
